### PR TITLE
feat: add Claude Code and Codex extension manifests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "google-cloud-storage",
+  "version": "1.0.0",
+  "description": "Vetted Google Cloud Storage skills for your coding agent.",
+  "author": {
+    "name": "Google LLC",
+    "email": "gemini-for-storage-eng@google.com"
+  },
+  "homepage": "https://cloud.google.com/storage",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/gemini-cli-extensions/google-cloud-storage",
+  "skills": "./skills/",
+  "userConfig": {}
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "google-cloud-storage",
+  "version": "1.0.0",
+  "description": "Vetted Google Cloud Storage skills for your coding agent.",
+  "author": {
+    "name": "Google LLC",
+    "email": "gemini-for-storage-eng@google.com"
+  },
+  "homepage": "https://cloud.google.com/storage",
+  "repository": "https://github.com/gemini-cli-extensions/google-cloud-storage",
+  "license": "Apache-2.0",
+  "keywords": [
+    "gcs",
+    "google-cloud-storage",
+    "storage",
+    "google-cloud"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Google Cloud Storage",
+    "shortDescription": "Google Cloud Storage skills for your coding agent.",
+    "developerName": "Google LLC",
+    "category": "Storage",
+    "capabilities": [
+      "Read"
+    ],
+    "defaultPrompt": [
+      "You are a Google Cloud Storage expert assistant. Help the user work with their Google Cloud Storage resources from their coding agent."
+    ]
+  }
+}


### PR DESCRIPTION
## What

  Packages this repository as an installable **Claude Code** and **OpenAI Codex**
  plugin by adding the plugin manifests. This lets the existing
  `gcs-security-assessment` skill be installed and loaded as a plugin (e.g. through
  the Data Agent Kit marketplace) instead of being consumed only as raw skill files.

  ## Changes

  - `.claude-plugin/plugin.json` — Claude Code plugin manifest (`skills: "./skills/"`).
  - `.codex-plugin/plugin.json` — Codex plugin manifest, including the `interface`
    block (display name, category, capabilities, default prompt).

Both are modeled off of other submodules in the data agent kit. Note that this change doesn't make our skills discoverable for that we need to bundle our repo with the data agent kit and later publish our own plugin. This is just the groundwork for those scenarios.